### PR TITLE
49 bug calculate polygon centroid should return xy as well

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fistools
 Title: Tools & data used for wildlife management & invasive species in Flanders
-Version: 1.1.1
+Version: 1.1.2
 Authors@R: c(
     person(given = "Sander", middle = "", family = "Devisscher", "sander.devisscher@inbo.be", 
       role = c("aut", "cre"), comment = c(ORCID = "0000-0003-2015-5731")),

--- a/R/calculate_polygon_centroid.R
+++ b/R/calculate_polygon_centroid.R
@@ -5,6 +5,17 @@
 #' @param sf_df A sf object with polygons
 #' @param id A character string with the name of the column containing the unique identifier
 #'
+#' @details
+#' The function always returns the latitude & longitude of the polygon centroid
+#' and the uncertainty of this centroid.
+#'
+#' The uncertainty is calculated as the maximum distance between the centroid and
+#' vertrexes of the polygon.
+#'
+#' When the crs of the input is not wgs84 centroidX & centroidY are also returned.
+#' The crs of these columns is equal to the crs of the input sf data frame.
+#'
+#'
 #' @return A data frame with the unique identifier, latitude, longitude and uncertainty of the centroid
 #'
 #' @examples
@@ -41,7 +52,8 @@
 #' @export
 #' @author Sander Devisscher
 
-calculate_polygon_centroid <- function(sf_df, id){
+calculate_polygon_centroid <- function(sf_df,
+                                       id){
   # Checks ####
   ## Check if the input is an sf object ####
   if(!inherits(sf_df, "sf")){

--- a/R/calculate_polygon_centroid.R
+++ b/R/calculate_polygon_centroid.R
@@ -77,6 +77,7 @@ calculate_polygon_centroid <- function(sf_df, id){
 
   ## Extract the CRS ####
   crs_wgs <- CRS_extracter("wgs")
+  input_crs <- sf::st_crs(sf_df)
 
   ## Transform the data to the correct CRS ####
   sf_df <- sf_df %>%
@@ -154,8 +155,6 @@ calculate_polygon_centroid <- function(sf_df, id){
   }
 
   ## Transform the data to a data frame ####
-  input_crs <- sf::st_crs(sf_df)
-
   centroids_data_final <- centroids_data_final %>%
       dplyr::mutate(centroidLatitude = sf::st_coordinates(geometry)[, 2],
                     centroidLongitude = sf::st_coordinates(geometry)[, 1])

--- a/docs/404.html
+++ b/docs/404.html
@@ -32,7 +32,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">fistools</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.2</span>
       </span>
     </div>
 

--- a/docs/CODE_OF_CONDUCT.html
+++ b/docs/CODE_OF_CONDUCT.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">fistools</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.2</span>
       </span>
     </div>
 

--- a/docs/LICENSE-text.html
+++ b/docs/LICENSE-text.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">fistools</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.2</span>
       </span>
     </div>
 

--- a/docs/LICENSE.html
+++ b/docs/LICENSE.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">fistools</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.2</span>
       </span>
     </div>
 

--- a/docs/authors.html
+++ b/docs/authors.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">fistools</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.2</span>
       </span>
     </div>
 
@@ -70,13 +70,13 @@
 
     <p>Devisscher S, Pallemaerts L, Delva S, Cartuyvels E, Bollen M (2024).
 <em>fistools: Tools &amp; data used for wildlife management &amp; invasive species in Flanders</em>.
-R package version 1.1.1.
+R package version 1.1.2.
 </p>
     <pre>@Manual{,
   title = {fistools: Tools &amp; data used for wildlife management &amp; invasive species in Flanders},
   author = {Sander Devisscher and Lynn Pallemaerts and Soria Delva and Emma Cartuyvels and Martijn Bollen},
   year = {2024},
-  note = {R package version 1.1.1},
+  note = {R package version 1.1.2},
 }</pre>
 
   </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -33,7 +33,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">fistools</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.2</span>
       </span>
     </div>
 

--- a/docs/pkgdown.yml
+++ b/docs/pkgdown.yml
@@ -2,4 +2,4 @@ pandoc: 2.9.2.1
 pkgdown: 2.1.0
 pkgdown_sha: ~
 articles: {}
-last_built: 2024-07-29T13:57Z
+last_built: 2024-07-29T16:03Z

--- a/docs/reference/CRS_extracter.html
+++ b/docs/reference/CRS_extracter.html
@@ -19,7 +19,7 @@ The EPSG code is 31370, but the proj4string is not the same as the one in the EP
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">fistools</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.2</span>
       </span>
     </div>
 

--- a/docs/reference/UUID_List.html
+++ b/docs/reference/UUID_List.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">fistools</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.2</span>
       </span>
     </div>
 

--- a/docs/reference/apply_grtsdb.html
+++ b/docs/reference/apply_grtsdb.html
@@ -18,7 +18,7 @@ GRTSdb if it is missing from your machine."><!-- mathjax --><script src="https:/
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">fistools</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.2</span>
       </span>
     </div>
 

--- a/docs/reference/boswachterijen.html
+++ b/docs/reference/boswachterijen.html
@@ -18,7 +18,7 @@ ANB."><!-- mathjax --><script src="https://cdnjs.cloudflare.com/ajax/libs/mathja
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">fistools</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.2</span>
       </span>
     </div>
 

--- a/docs/reference/calculate_polygon_centroid.html
+++ b/docs/reference/calculate_polygon_centroid.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">fistools</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.2</span>
       </span>
     </div>
 
@@ -62,6 +62,15 @@
     <div id="value">
     <h2>Value</h2>
     <p>A data frame with the unique identifier, latitude, longitude and uncertainty of the centroid</p>
+    </div>
+    <div id="details">
+    <h2>Details</h2>
+    <p>The function always returns the latitude &amp; longitude of the polygon centroid
+and the uncertainty of this centroid.</p>
+<p>The uncertainty is calculated as the maximum distance between the centroid and
+vertrexes of the polygon.</p>
+<p>When the crs of the input is not wgs84 centroidX &amp; centroidY are also returned.
+The crs of these columns is equal to the crs of the input sf data frame.</p>
     </div>
     <div id="author">
     <h2>Author</h2>

--- a/docs/reference/check.html
+++ b/docs/reference/check.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">fistools</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.2</span>
       </span>
     </div>
 

--- a/docs/reference/cleanup_sqlite.html
+++ b/docs/reference/cleanup_sqlite.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">fistools</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.2</span>
       </span>
     </div>
 

--- a/docs/reference/col_content_compare.html
+++ b/docs/reference/col_content_compare.html
@@ -19,7 +19,7 @@ missing from the second column, and the values that are in both columns."><!-- m
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">fistools</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.2</span>
       </span>
     </div>
 

--- a/docs/reference/colcompare.html
+++ b/docs/reference/colcompare.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">fistools</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.2</span>
       </span>
     </div>
 

--- a/docs/reference/collect_osm_features.html
+++ b/docs/reference/collect_osm_features.html
@@ -23,7 +23,7 @@ osm_points: city names
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">fistools</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.2</span>
       </span>
     </div>
 

--- a/docs/reference/download_dep_media.html
+++ b/docs/reference/download_dep_media.html
@@ -18,7 +18,7 @@ dataset which matches the given parameters."><!-- mathjax --><script src="https:
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">fistools</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.2</span>
       </span>
     </div>
 

--- a/docs/reference/download_gdrive_if_missing.html
+++ b/docs/reference/download_gdrive_if_missing.html
@@ -19,7 +19,7 @@ it again."><!-- mathjax --><script src="https://cdnjs.cloudflare.com/ajax/libs/m
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">fistools</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.2</span>
       </span>
     </div>
 

--- a/docs/reference/download_seq_media.html
+++ b/docs/reference/download_seq_media.html
@@ -18,7 +18,7 @@ sequence which matches the given parameters."><!-- mathjax --><script src="https
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">fistools</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.2</span>
       </span>
     </div>
 

--- a/docs/reference/drg_example.html
+++ b/docs/reference/drg_example.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">fistools</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.2</span>
       </span>
     </div>
 

--- a/docs/reference/index.html
+++ b/docs/reference/index.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">fistools</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.2</span>
       </span>
     </div>
 

--- a/docs/reference/install_sp.html
+++ b/docs/reference/install_sp.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">fistools</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.2</span>
       </span>
     </div>
 

--- a/docs/reference/label_converter.html
+++ b/docs/reference/label_converter.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">fistools</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.2</span>
       </span>
     </div>
 

--- a/docs/reference/lib_crs.html
+++ b/docs/reference/lib_crs.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">fistools</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.2</span>
       </span>
     </div>
 

--- a/man/calculate_polygon_centroid.Rd
+++ b/man/calculate_polygon_centroid.Rd
@@ -17,6 +17,16 @@ A data frame with the unique identifier, latitude, longitude and uncertainty of 
 \description{
 This function calculates the centroid of a polygon and returns the latitude, longitude and uncertainty of the centroid.
 }
+\details{
+The function always returns the latitude & longitude of the polygon centroid
+and the uncertainty of this centroid.
+
+The uncertainty is calculated as the maximum distance between the centroid and
+vertrexes of the polygon.
+
+When the crs of the input is not wgs84 centroidX & centroidY are also returned.
+The crs of these columns is equal to the crs of the input sf data frame.
+}
 \examples{
 \dontrun{
 # Example of how to use the calculate_polygon_centroid function


### PR DESCRIPTION
function now returns centroidX & centroidY when crs of input is not WGS 84. Otherwise only centroidLatitude & centroidLongitude are returned.

fixes #49 