### PR TITLE
fix agouti sequence url

### DIFF
--- a/R/agouti_imager.R
+++ b/R/agouti_imager.R
@@ -84,8 +84,9 @@ agouti_imager <- function(agouti_prj_id,
 
   for (i in 1:length(seqID)) {
     # Open URL
-    browseURL(url = paste0("https://www.agouti.eu/project/", agouti_prj_id,
-                           "/observations/edit-sequence/",
+    browseURL(url = paste0("https://www.agouti.eu/project/",
+                           project_id,
+                           "/annotate/sequence/",
                            seqID[i]))
     # append seqID to done file to skip next time
 


### PR DESCRIPTION
This pull request updates the URL structure used in the `agouti_imager` function to match changes in the Agouti platform, ensuring that the function now directs users to the correct annotation page for each sequence.

**Update to URL construction:**

* Modified the `browseURL` call in `agouti_imager` to use `project_id` instead of `agouti_prj_id`, and changed the URL path from `/observations/edit-sequence/` to `/annotate/sequence/` to reflect the new annotation workflow in Agouti.