### PR TITLE
use agouti_prj_id

### DIFF
--- a/R/agouti_imager.R
+++ b/R/agouti_imager.R
@@ -85,7 +85,7 @@ agouti_imager <- function(agouti_prj_id,
   for (i in 1:length(seqID)) {
     # Open URL
     browseURL(url = paste0("https://www.agouti.eu/project/",
-                           project_id,
+                           agouti_prj_id,
                            "/annotate/sequence/",
                            seqID[i]))
     # append seqID to done file to skip next time


### PR DESCRIPTION
This pull request makes a minor update to the `agouti_imager` function, correcting the URL construction to use the `agouti_prj_id` parameter instead of the incorrect `project_id`. This ensures the function correctly navigates to the intended project page.

* Fixed the URL in `agouti_imager` to use the `agouti_prj_id` parameter, ensuring correct project navigation.