### PR TITLE
152 bug connect to bucket now needs mfa

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fistools
 Title: Tools & data used for wildlife management & invasive species in Flanders
-Version: 1.2.30
+Version: 1.2.31
 Authors@R: c(
     person(given = "Sander", middle = "", family = "Devisscher", "sander.devisscher@inbo.be", 
       role = c("aut", "cre"), comment = c(ORCID = "0000-0003-2015-5731")),

--- a/R/connect_to_bucket.R
+++ b/R/connect_to_bucket.R
@@ -55,6 +55,14 @@ connect_to_bucket <- function(bucket_name,
   if(file.exists("../../../bin/aws-cli-mfa-login.exe")){
     mfa_code <- svDialogs::dlg_input("Enter MFA Code: ")$res
 
+    if(nchar(mfa_code) != 6){
+      warning("The MFA code entered might not be valid! A 6 character value is expected")
+    }
+
+    if(is.na(as.integer(mfa_code))){
+      warning("The MFA code entered might not be valid! A integer value is expected")
+    }
+
     cmd <- paste0(normalizePath("../../../bin/aws-cli-mfa-login.exe"), ' aws-mfa -u ',
                   Sys.getenv("USERNAME"),
                   ' -a ', bucket_type, ' -r ', role)

--- a/R/connect_to_bucket.R
+++ b/R/connect_to_bucket.R
@@ -52,10 +52,14 @@ connect_to_bucket <- function(bucket_name,
   # Refresh session token ####
   # Onderstaande code maakt een profiel aan met een sessiontoken die één uur
   # geldig blijft. Deze heb je nodig om verbinding te maken met de s3 buckets.
-  if(file.exists("../../../bin/aws-cli-mfa-login")){
-    system(paste0('python ../../../bin/aws-cli-mfa-login -u ',
+  if(file.exists("../../../bin/aws-cli-mfa-login.exe")){
+    mfa_code <- readline("Enter MFA Code: ")
+
+    cmd <- paste0(normalizePath("../../../bin/aws-cli-mfa-login.exe"), ' aws-mfa -u ',
                   Sys.getenv("USERNAME"),
-                  ' -a ', bucket_type, ' -r ', role))
+                  ' -a ', bucket_type, ' -r ', role)
+
+    system(cmd, input = mfa_code, intern = FALSE, ignore.stdout = FALSE, ignore.stderr = FALSE, wait = TRUE)
   }else{
     stop("Installeer aws-cli-mfa-login van inbo/devops-tools in je windows home
          directory, zie details")

--- a/R/connect_to_bucket.R
+++ b/R/connect_to_bucket.R
@@ -53,7 +53,7 @@ connect_to_bucket <- function(bucket_name,
   # Onderstaande code maakt een profiel aan met een sessiontoken die één uur
   # geldig blijft. Deze heb je nodig om verbinding te maken met de s3 buckets.
   if(file.exists("../../../bin/aws-cli-mfa-login.exe")){
-    mfa_code <- readline("Enter MFA Code: ")
+    mfa_code <- svDialogs::dlg_input("Enter MFA Code: ")$res
 
     cmd <- paste0(normalizePath("../../../bin/aws-cli-mfa-login.exe"), ' aws-mfa -u ',
                   Sys.getenv("USERNAME"),

--- a/R/connect_to_bucket.R
+++ b/R/connect_to_bucket.R
@@ -22,15 +22,14 @@
 #' Na de installatie moeten je *AWS credentials* eenmalig aangemaakt worden.
 #' Voer hiervoor `aws configure` uit in _windows powershell_. De credentials
 #' kan je bekomen bij Jens Polspoel.
-#' -*devops-toolkit* moet lokaal worden geïnstalleerd dit doe je door
-#' *https://github.com/inbo/devops-toolkit* te clonen dmv _github dekstop_.
-#' Vervolgens kopiëer je *aws-cli-mfa-login.py* & *common.py* naar de Home
+#' -*devops-toolkit* moet lokaal worden geïnstalleerd dit doe je door de laatste
+#' versie van *https://github.com/inbo/devops-toolkit/releases/tag/ (>= v0.6)*
+#' te downloaden.
+#' Vervolgens kopiëer je *aws-cli-mfa-login* naar de Home
 #' Directory van Windows. Default is dat *C:/Users/%voornaam_achternaam%/bin*.
-#' -*Python* moet worden geïnstalleerd als dat nog niet gebeurd is. Dit kan
-#' rechtstreeks in _R_ met onderstaande code:
-#' `install.packages("reticulate")`
-#' `reticulate::install_python()`
-#' `system('pip install boto3')`
+#' Hernoem het bestand vervolgens naar *aws-cli-mfa-login.exe*.
+#'
+#' _Python is niet meer vereist voor het gebruik van deze functie_
 #'
 #' @return Dataframe met een lijst van bestanden op de bucket met relevante info.
 #'

--- a/man/connect_to_bucket.Rd
+++ b/man/connect_to_bucket.Rd
@@ -34,15 +34,14 @@ heb je admin rechten nodig, een \emph{ict helpdesk call} is dus aan de orde.
 Na de installatie moeten je \emph{AWS credentials} eenmalig aangemaakt worden.
 Voer hiervoor \verb{aws configure} uit in \emph{windows powershell}. De credentials
 kan je bekomen bij Jens Polspoel.
--\emph{devops-toolkit} moet lokaal worden geïnstalleerd dit doe je door
-\emph{https://github.com/inbo/devops-toolkit} te clonen dmv \emph{github dekstop}.
-Vervolgens kopiëer je \emph{aws-cli-mfa-login.py} & \emph{common.py} naar de Home
+-\emph{devops-toolkit} moet lokaal worden geïnstalleerd dit doe je door de laatste
+versie van \emph{https://github.com/inbo/devops-toolkit/releases/tag/ (>= v0.6)}
+te downloaden.
+Vervolgens kopiëer je \emph{aws-cli-mfa-login} naar de Home
 Directory van Windows. Default is dat \emph{C:/Users/\%voornaam_achternaam\%/bin}.
--\emph{Python} moet worden geïnstalleerd als dat nog niet gebeurd is. Dit kan
-rechtstreeks in \emph{R} met onderstaande code:
-\code{install.packages("reticulate")}
-\code{reticulate::install_python()}
-\code{system('pip install boto3')}
+Hernoem het bestand vervolgens naar \emph{aws-cli-mfa-login.exe}.
+
+\emph{Python is niet meer vereist voor het gebruik van deze functie}
 }
 
 \examples{


### PR DESCRIPTION
This pull request updates the setup instructions and authentication process for connecting to an S3 bucket, removing the dependency on Python and streamlining the use of the `aws-cli-mfa-login` tool. The documentation and code are updated to reflect the new process, which now uses a standalone executable and prompts the user for an MFA code.

**Documentation and setup instructions:**
- Updated the installation instructions to require downloading the latest release (>= v0.6) of `devops-toolkit` from GitHub releases, instead of cloning the repository and copying Python files. The user now needs to copy the `aws-cli-mfa-login` executable and rename it to `aws-cli-mfa-login.exe`. The requirement for Python and related packages has been removed, clarifying that Python is no longer needed. [[1]](diffhunk://#diff-fa14431dde1db32690d632433fd7b9763e07b8d2601b6ed340c31778d7b446f2L25-R32) [[2]](diffhunk://#diff-65189876da4cab96c682bdde6a327f57f9e294dadcb60967bb160cd824a8c47aL37-R44)

**Authentication process improvements:**
- Changed the authentication logic to use the `aws-cli-mfa-login.exe` executable directly, prompt the user for a 6-digit MFA code, and perform validation on the input. The system call now supplies the MFA code as input to the executable, and Python is no longer invoked.

@RuttenAnneleen je mag het gewoon goedkeuren 😉 